### PR TITLE
Initialize Next.js starter for Garmin R10 CSV ingestion

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.next
+out
+coverage
+.env*

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Golfcoachr10 starter
+
+A lightweight Next.js starter to ingest Garmin R10 exported CSV files, normalize known columns, and show quick session-level summaries.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+Then open [http://localhost:3000](http://localhost:3000).
+
+## Current capabilities
+
+- Upload a CSV file in-browser.
+- Parse rows with flexible header aliases (for common Garmin export naming variants).
+- Show session metrics (shot count, average carry, ball speed, launch angle, spin).
+- Show per-club shot counts and average carry.
+
+## Next suggested steps
+
+- Persist uploads and computed metrics in a database.
+- Add shot dispersion visuals and rolling averages.
+- Support user accounts and historical session comparisons.

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,95 @@
+:root {
+  color-scheme: light dark;
+  --bg: #0f172a;
+  --surface: #1e293b;
+  --surface-soft: #334155;
+  --text: #f8fafc;
+  --muted: #cbd5e1;
+  --border: #475569;
+  --error: #fca5a5;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Inter, system-ui, sans-serif;
+  background: radial-gradient(circle at top, #1d4ed8, var(--bg) 35%);
+  color: var(--text);
+}
+
+.page {
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 3rem 1.25rem 4rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 700;
+  color: var(--muted);
+}
+
+.stack {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.uploader {
+  display: grid;
+  gap: 0.5rem;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+}
+
+input[type='file'] {
+  color: var(--muted);
+}
+
+.summary-grid {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.summary-grid article {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.75rem;
+  background: rgba(15, 23, 42, 0.6);
+}
+
+.summary-grid h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.summary-grid p {
+  margin: 0.5rem 0 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.75rem;
+}
+
+th,
+td {
+  text-align: left;
+  border-bottom: 1px solid var(--border);
+  padding: 0.6rem 0.35rem;
+}
+
+.error {
+  color: var(--error);
+  font-weight: 600;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Golfcoach R10',
+  description: 'Starter Next.js app for ingesting Garmin R10 CSV range sessions.'
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,18 @@
+import CsvUploader from '@/components/csv-uploader';
+
+export default function HomePage() {
+  return (
+    <main className="page">
+      <header>
+        <p className="eyebrow">Golfcoachr10</p>
+        <h1>Garmin R10 Range Session Importer</h1>
+        <p>
+          This starter app lets you upload exported CSV files from Garmin R10 sessions and see quick
+          summaries by shot and club.
+        </p>
+      </header>
+
+      <CsvUploader />
+    </main>
+  );
+}

--- a/components/csv-uploader.tsx
+++ b/components/csv-uploader.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import Papa from 'papaparse';
+import { useMemo, useState } from 'react';
+import { mapRowsToShots, summarizeSession, type ShotRecord } from '@/lib/r10';
+
+const formatValue = (value: number | null, suffix = '') =>
+  value === null ? '—' : `${value.toFixed(1)}${suffix}`;
+
+export default function CsvUploader() {
+  const [shots, setShots] = useState<ShotRecord[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  const summary = useMemo(() => summarizeSession(shots), [shots]);
+
+  const onFileChange = (file: File) => {
+    setError(null);
+
+    Papa.parse<Record<string, string>>(file, {
+      header: true,
+      skipEmptyLines: true,
+      complete(results) {
+        const nextShots = mapRowsToShots(results.data);
+        if (!nextShots.length) {
+          setError('No recognizable shot rows were found in this CSV.');
+          setShots([]);
+          return;
+        }
+
+        setShots(nextShots);
+      },
+      error(parseError) {
+        setError(parseError.message);
+        setShots([]);
+      }
+    });
+  };
+
+  return (
+    <div className="stack">
+      <label className="uploader" htmlFor="csvInput">
+        <input
+          id="csvInput"
+          accept=".csv,text/csv"
+          type="file"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            if (file) onFileChange(file);
+          }}
+        />
+        <strong>Upload Garmin R10 CSV</strong>
+        <span>Choose an exported range session to parse and summarize.</span>
+      </label>
+
+      {error && <p className="error">{error}</p>}
+
+      {shots.length > 0 && (
+        <>
+          <section className="summary-grid" aria-label="Session summary">
+            <article>
+              <h3>Shots</h3>
+              <p>{summary.shots}</p>
+            </article>
+            <article>
+              <h3>Avg Carry</h3>
+              <p>{formatValue(summary.avgCarryYds, ' yds')}</p>
+            </article>
+            <article>
+              <h3>Avg Ball Speed</h3>
+              <p>{formatValue(summary.avgBallSpeedMph, ' mph')}</p>
+            </article>
+            <article>
+              <h3>Avg Spin</h3>
+              <p>{formatValue(summary.avgSpinRpm, ' rpm')}</p>
+            </article>
+          </section>
+
+          <section>
+            <h2>By Club</h2>
+            <table>
+              <thead>
+                <tr>
+                  <th>Club</th>
+                  <th>Shots</th>
+                  <th>Avg Carry</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.clubs.map((club) => (
+                  <tr key={club.name}>
+                    <td>{club.name}</td>
+                    <td>{club.shots}</td>
+                    <td>{formatValue(club.avgCarryYds, ' yds')}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}

--- a/lib/r10.ts
+++ b/lib/r10.ts
@@ -1,0 +1,112 @@
+export type ShotRecord = {
+  club: string;
+  ballSpeedMph: number | null;
+  launchAngleDeg: number | null;
+  carryYds: number | null;
+  totalYds: number | null;
+  sideYds: number | null;
+  spinRpm: number | null;
+  raw: Record<string, string>;
+};
+
+export type SessionSummary = {
+  shots: number;
+  avgCarryYds: number | null;
+  avgBallSpeedMph: number | null;
+  avgLaunchAngleDeg: number | null;
+  avgSpinRpm: number | null;
+  clubs: { name: string; shots: number; avgCarryYds: number | null }[];
+};
+
+const keyAliases: Record<keyof Omit<ShotRecord, 'raw'>, string[]> = {
+  club: ['club', 'club type'],
+  ballSpeedMph: ['ball speed', 'ball speed (mph)'],
+  launchAngleDeg: ['launch angle', 'launch angle (deg)'],
+  carryYds: ['carry', 'carry distance', 'carry (yds)', 'carry (yards)'],
+  totalYds: ['total', 'total distance', 'total (yds)', 'total (yards)'],
+  sideYds: ['side', 'side distance', 'side (yds)'],
+  spinRpm: ['spin', 'spin rate', 'spin (rpm)']
+};
+
+const normalizeHeader = (value: string) =>
+  value
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]/g, ' ')
+    .replace(/\s+/g, ' ');
+
+const numeric = (value: string | undefined) => {
+  if (!value) return null;
+  const n = Number(value.replace(/[^\d.-]/g, ''));
+  return Number.isFinite(n) ? n : null;
+};
+
+const avg = (values: Array<number | null>) => {
+  const numbers = values.filter((v): v is number => typeof v === 'number');
+  if (!numbers.length) return null;
+  const total = numbers.reduce((sum, v) => sum + v, 0);
+  return Math.round((total / numbers.length) * 10) / 10;
+};
+
+const resolveValue = (
+  row: Record<string, string>,
+  aliases: string[],
+  transform: (v: string | undefined) => string | number | null
+) => {
+  const key = Object.keys(row).find((k) => aliases.includes(normalizeHeader(k)));
+  return transform(key ? row[key] : undefined);
+};
+
+export const mapRowsToShots = (rows: Record<string, string>[]): ShotRecord[] => {
+  return rows
+    .map((row) => {
+      const shot: ShotRecord = {
+        club: String(resolveValue(row, keyAliases.club, (v) => v?.trim() ?? 'Unknown')),
+        ballSpeedMph: resolveValue(row, keyAliases.ballSpeedMph, numeric) as number | null,
+        launchAngleDeg: resolveValue(row, keyAliases.launchAngleDeg, numeric) as number | null,
+        carryYds: resolveValue(row, keyAliases.carryYds, numeric) as number | null,
+        totalYds: resolveValue(row, keyAliases.totalYds, numeric) as number | null,
+        sideYds: resolveValue(row, keyAliases.sideYds, numeric) as number | null,
+        spinRpm: resolveValue(row, keyAliases.spinRpm, numeric) as number | null,
+        raw: row
+      };
+
+      return shot;
+    })
+    .filter((shot) =>
+      [
+        shot.club !== 'Unknown',
+        shot.ballSpeedMph !== null,
+        shot.launchAngleDeg !== null,
+        shot.carryYds !== null,
+        shot.totalYds !== null,
+        shot.sideYds !== null,
+        shot.spinRpm !== null
+      ].some(Boolean));
+};
+
+export const summarizeSession = (shots: ShotRecord[]): SessionSummary => {
+  const grouped = new Map<string, ShotRecord[]>();
+
+  for (const shot of shots) {
+    const key = shot.club || 'Unknown';
+    const existing = grouped.get(key) ?? [];
+    existing.push(shot);
+    grouped.set(key, existing);
+  }
+
+  return {
+    shots: shots.length,
+    avgCarryYds: avg(shots.map((s) => s.carryYds)),
+    avgBallSpeedMph: avg(shots.map((s) => s.ballSpeedMph)),
+    avgLaunchAngleDeg: avg(shots.map((s) => s.launchAngleDeg)),
+    avgSpinRpm: avg(shots.map((s) => s.spinRpm)),
+    clubs: [...grouped.entries()]
+      .map(([name, list]) => ({
+        name,
+        shots: list.length,
+        avgCarryYds: avg(list.map((s) => s.carryYds))
+      }))
+      .sort((a, b) => b.shots - a.shots)
+  };
+};

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "golfcoachr10",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.5",
+    "papaparse": "^5.4.1",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.10",
+    "@types/papaparse": "^5.3.14",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.5",
+    "typescript": "^5.5.3"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal Next.js + TypeScript starter to ingest exported Garmin R10 CSV range sessions, normalize common header variants, and present quick session summaries in-browser.

### Description
- Scaffolded a Next.js app and project configuration files including `package.json`, `tsconfig.json`, `next.config.mjs`, `next-env.d.ts`, `.eslintrc.json`, and `.gitignore`.
- Added a client CSV uploader UI (`app/page.tsx`, `components/csv-uploader.tsx`) that parses uploaded CSVs with `papaparse` and displays session and per-club summaries.
- Implemented parsing and summarization utilities in `lib/r10.ts` with header alias mapping, numeric normalization, averaging helpers, and a stricter filter to exclude rows without meaningful shot data.
- Added global styling (`app/globals.css`) and a `README.md` describing usage and next steps.

### Testing
- Ran `npm install` which failed due to a `403 Forbidden` response from the npm registry, so dependencies were not installed in this environment.
- Attempted to run a Playwright script to visit `http://127.0.0.1:3000`, which failed with `ERR_EMPTY_RESPONSE` because the app server was not running (dependency install failed).
- No automated unit tests were executed in this environment beyond the dependency/install and Playwright checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993a359e494832db1945295b79efa5b)