### PR TITLE
Use Club Type as canonical key for club summaries

### DIFF
--- a/components/csv-uploader.tsx
+++ b/components/csv-uploader.tsx
@@ -88,7 +88,16 @@ export default function CsvUploader() {
               <tbody>
                 {summary.clubs.map((club) => (
                   <tr key={club.name}>
-                    <td>{club.name}</td>
+                    <td>
+                      <div>{club.displayName}</div>
+                      {(club.shotLabels.length > 1 || club.modelLabels.length > 0) && (
+                        <small>
+                          {club.shotLabels.length > 1 && `Aliases: ${club.shotLabels.join(', ')}`}
+                          {club.shotLabels.length > 1 && club.modelLabels.length > 0 && ' • '}
+                          {club.modelLabels.length > 0 && `Models: ${club.modelLabels.join(', ')}`}
+                        </small>
+                      )}
+                    </td>
                     <td>{club.shots}</td>
                     <td>{formatValue(club.avgCarryYds, ' yds')}</td>
                   </tr>


### PR DESCRIPTION
### Motivation

- Avoid club fragmentation by treating `Club Type` as the canonical identity when aggregating shots. 
- Preserve `Club Name` and `Brand/Model` as optional metadata so variant labels and models remain visible for context. 
- Surface a stable display label while still showing aliases and model variants to help users reconcile inconsistent CSV labels.

### Description

- Updated the shot model to include `clubType`, `clubName`, `clubModel`, and a computed `displayClub`, replacing the single `club` field. 
- Extended `keyAliases` to recognize `club type`, `club name`, and `brand/model` headers and updated `mapRowsToShots` to populate the new fields. 
- Modified `summarizeSession` to group strictly by `clubType` and to expose per-group `displayName`, `shotLabels`, and `modelLabels` so variants are visible in summaries. 
- Updated the club table UI in `components/csv-uploader.tsx` to render `displayName` and, when present, show alias and model metadata alongside shot counts and averages.

### Testing

- Ran type checking with `npx tsc --noEmit` which completed successfully. 
- Attempted linting with `npm run lint` but it failed in this environment due to a missing ESLint config dependency referencing `next/typescript`. 
- Started the dev server and captured a UI screenshot to validate the updated summary table rendering (dev server boot and page render completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fd5a04c8832dbbafeb88943d0a40)